### PR TITLE
fix: allow provision type omit empty in worker pool struct

### DIFF
--- a/kubernetes_engine_cluster.go
+++ b/kubernetes_engine_cluster.go
@@ -11,35 +11,35 @@ import (
 
 // EverywhereNode represents a Kubernetes everywhere node
 type EverywhereNode struct {
-	ID        string `json:"id" yaml:"id"`
-	Shoot     string `json:"shoot" yaml:"shoot"`
-	PoolID    string `json:"pool_id" yaml:"pool_id"`
-	NodeName  string `json:"node_name" yaml:"node_name"`
-	PublicIP  string `json:"public_ip" yaml:"public_ip"`
+	ID        string `json:"id"         yaml:"id"`
+	Shoot     string `json:"shoot"      yaml:"shoot"`
+	PoolID    string `json:"pool_id"    yaml:"pool_id"`
+	NodeName  string `json:"node_name"  yaml:"node_name"`
+	PublicIP  string `json:"public_ip"  yaml:"public_ip"`
 	PrivateIP string `json:"private_ip" yaml:"private_ip"`
-	Region    string `json:"region" yaml:"region"`
-	UUID      string `json:"uuid" yaml:"uuid"`
+	Region    string `json:"region"     yaml:"region"`
+	UUID      string `json:"uuid"       yaml:"uuid"`
 	CreatedAt string `json:"created_at" yaml:"created_at"`
 	UpdatedAt string `json:"updated_at" yaml:"updated_at"`
-	Deleted   bool   `json:"deleted" yaml:"deleted"`
+	Deleted   bool   `json:"deleted"    yaml:"deleted"`
 }
 
 // ClusterCreateRequest represents the request body for creating a Kubernetes cluster
 type ClusterCreateRequest struct {
-	Name         string       `json:"name" yaml:"name"`
-	Version      string       `json:"version" yaml:"version"`
+	Name         string       `json:"name"                   yaml:"name"`
+	Version      string       `json:"version"                yaml:"version"`
 	AutoUpgrade  bool         `json:"auto_upgrade,omitempty" yaml:"auto_upgrade,omitempty"`
-	VPCNetworkID string       `json:"private_network_id" yaml:"private_network_id"`
+	VPCNetworkID string       `json:"private_network_id"     yaml:"private_network_id"`
 	EnableCloud  bool         `json:"enable_cloud,omitempty" yaml:"enable_cloud,omitempty"`
-	Tags         []string     `json:"tags,omitempty" yaml:"tags,omitempty"`
-	WorkerPools  []WorkerPool `json:"worker_pools" yaml:"worker_pools"`
+	Tags         []string     `json:"tags,omitempty"         yaml:"tags,omitempty"`
+	WorkerPools  []WorkerPool `json:"worker_pools"           yaml:"worker_pools"`
 }
 
 // ControllerVersion represents the version of the controller
 type ControllerVersion struct {
-	ID          string `json:"id,omitempty" yaml:"id,omitempty"`
-	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
-	Description string `json:"description" yaml:"description"`
+	ID          string `json:"id,omitempty"       yaml:"id,omitempty"`
+	Name        string `json:"name,omitempty"     yaml:"name,omitempty"`
+	Description string `json:"description"        yaml:"description"`
 	K8SVersion  string `json:"kubernetes_version" yaml:"kubernetes_version"`
 }
 
@@ -50,18 +50,18 @@ type Clusters struct {
 
 // Cluster represents a Kubernetes cluster
 type Cluster struct {
-	UID              string            `json:"uid" yaml:"uid"`
-	Name             string            `json:"name" yaml:"name"`
-	Version          ControllerVersion `json:"version" yaml:"version"`
+	UID              string            `json:"uid"                yaml:"uid"`
+	Name             string            `json:"name"               yaml:"name"`
+	Version          ControllerVersion `json:"version"            yaml:"version"`
 	VPCNetworkID     string            `json:"private_network_id" yaml:"private_network_id"`
-	AutoUpgrade      bool              `json:"auto_upgrade" yaml:"auto_upgrade"`
-	Tags             []string          `json:"tags" yaml:"tags"`
-	ProvisionStatus  string            `json:"provision_status" yaml:"provision_status"`
-	ClusterStatus    string            `json:"cluster_status" yaml:"cluster_status"`
-	CreatedAt        string            `json:"created_at" yaml:"created_at"`
-	CreatedBy        string            `json:"created_by" yaml:"created_by"`
+	AutoUpgrade      bool              `json:"auto_upgrade"       yaml:"auto_upgrade"`
+	Tags             []string          `json:"tags"               yaml:"tags"`
+	ProvisionStatus  string            `json:"provision_status"   yaml:"provision_status"`
+	ClusterStatus    string            `json:"cluster_status"     yaml:"cluster_status"`
+	CreatedAt        string            `json:"created_at"         yaml:"created_at"`
+	CreatedBy        string            `json:"created_by"         yaml:"created_by"`
 	WorkerPoolsCount int               `json:"worker_pools_count" yaml:"worker_pools_count"`
-	ProvisionType    string            `json:"provision_type" yaml:"provision_type"`
+	ProvisionType    string            `json:"provision_type"     yaml:"provision_type"`
 }
 
 // ExtendedCluster represents a Kubernetes cluster with additional worker pools' information
@@ -73,7 +73,7 @@ type ExtendedCluster struct {
 // ClusterStat represents the statistic information of a Kubernetes cluster
 type ClusterStat struct {
 	WorkerPoolCount int `json:"worker_pools" yaml:"worker_pools"`
-	TotalCPU        int `json:"total_cpu" yaml:"total_cpu"`
+	TotalCPU        int `json:"total_cpu"    yaml:"total_cpu"`
 	TotalMemory     int `json:"total_memory" yaml:"total_memory"`
 }
 
@@ -148,7 +148,6 @@ func (c *kubernetesEngineService) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	resp, err := c.client.Do(ctx, req)
-
 	if err != nil {
 		fmt.Println("error send req")
 		return err

--- a/kubernetes_engine_pool.go
+++ b/kubernetes_engine_pool.go
@@ -11,37 +11,37 @@ import (
 
 // WorkerPool represents worker pool information
 type WorkerPool struct {
-	Name              string   `json:"name" yaml:"name"`
-	ProvisionType	  string   `json:"provision_type" yaml:"provision_type"`
-	Version           string   `json:"version,omitempty" yaml:"version,omitempty"`
-	Flavor            string   `json:"flavor" yaml:"flavor"`
-	ProfileType       string   `json:"profile_type" yaml:"profile_type"`
-	VolumeType        string   `json:"volume_type" yaml:"volume_type"`
-	VolumeSize        int      `json:"volume_size" yaml:"volume_size"`
-	AvailabilityZone  string   `json:"availability_zone" yaml:"availability_zone"`
-	DesiredSize       int      `json:"desired_size" yaml:"desired_size"`
-	EnableAutoScaling bool     `json:"enable_autoscaling,omitempty" yaml:"enable_autoscaling,omitempty"`
-	MinSize           int      `json:"min_size,omitempty" yaml:"min_size,omitempty"`
-	MaxSize           int      `json:"max_size,omitempty" yaml:"max_size,omitempty"`
-	Tags              []string `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Taints			  []Taint  `json:"taints,omitempty" yaml:"taints,omitempty"`
-	Labels			  map[string]string	`json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name              string            `json:"name"                         yaml:"name"`
+	ProvisionType     string            `json:"provision_type,omitempty"     yaml:"provision_type,omitempty"`
+	Version           string            `json:"version,omitempty"            yaml:"version,omitempty"`
+	Flavor            string            `json:"flavor"                       yaml:"flavor"`
+	ProfileType       string            `json:"profile_type"                 yaml:"profile_type"`
+	VolumeType        string            `json:"volume_type"                  yaml:"volume_type"`
+	VolumeSize        int               `json:"volume_size"                  yaml:"volume_size"`
+	AvailabilityZone  string            `json:"availability_zone"            yaml:"availability_zone"`
+	DesiredSize       int               `json:"desired_size"                 yaml:"desired_size"`
+	EnableAutoScaling bool              `json:"enable_autoscaling,omitempty" yaml:"enable_autoscaling,omitempty"`
+	MinSize           int               `json:"min_size,omitempty"           yaml:"min_size,omitempty"`
+	MaxSize           int               `json:"max_size,omitempty"           yaml:"max_size,omitempty"`
+	Tags              []string          `json:"tags,omitempty"               yaml:"tags,omitempty"`
+	Taints            []Taint           `json:"taints,omitempty"             yaml:"taints,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"             yaml:"labels,omitempty"`
 }
 
 type Taint struct {
-	Effect		string	`json:"effect" yaml:"effect"`
-	Key			string	`json:"key" yaml:"labels,omitempty"`
-	Value		string	`json:"value,omitempty" yaml:"value,omitempty"`
+	Effect string `json:"effect"          yaml:"effect"`
+	Key    string `json:"key"             yaml:"labels,omitempty"`
+	Value  string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // ExtendedWorkerPool represents worker pool information with addition fields
 type ExtendedWorkerPool struct {
 	WorkerPool
-	UID                string `json:"id" yaml:"id"`
-	ProvisionStatus    string `json:"provision_status" yaml:"provision_status"`
-	LaunchConfigID     string `json:"launch_config_id" yaml:"launch_config_id"`
+	UID                string `json:"id"                   yaml:"id"`
+	ProvisionStatus    string `json:"provision_status"     yaml:"provision_status"`
+	LaunchConfigID     string `json:"launch_config_id"     yaml:"launch_config_id"`
 	AutoScalingGroupID string `json:"autoscaling_group_id" yaml:"autoscaling_group_id"`
-	CreatedAt          string `json:"created_at" yaml:"created_at"`
+	CreatedAt          string `json:"created_at"           yaml:"created_at"`
 }
 
 // ExtendedWorkerPools is a list of ExtendedWorkerPool
@@ -56,11 +56,11 @@ type AddWorkerPoolsRequest struct {
 
 // PoolNode represents node information in a worker pool
 type PoolNode struct {
-	ID           string   `json:"id" yaml:"id"`
-	Name         string   `json:"name" yaml:"name"`
-	PhysicalID   string   `json:"physical_id" yaml:"physical_id"`
-	IPAddresses  []string `json:"ip_addresses" yaml:"ip_addresses"`
-	Status       string   `json:"status" yaml:"status"`
+	ID           string   `json:"id"            yaml:"id"`
+	Name         string   `json:"name"          yaml:"name"`
+	PhysicalID   string   `json:"physical_id"   yaml:"physical_id"`
+	IPAddresses  []string `json:"ip_addresses"  yaml:"ip_addresses"`
+	Status       string   `json:"status"        yaml:"status"`
 	StatusReason string   `json:"status_reason" yaml:"status_reason"`
 }
 
@@ -72,17 +72,21 @@ type WorkerPoolWithNodes struct {
 
 // UpdateWorkerPoolRequest represents the request body to update worker pool
 type UpdateWorkerPoolRequest struct {
-	DesiredSize       int    `json:"desired_size,omitempty" yaml:"desired_size,omitempty"`
-	EnableAutoScaling bool   `json:"enable_autoscaling,omitempty" yaml:"enable_autoscaling,omitempty"`
-	MinSize           int    `json:"min_size,omitempty" yaml:"min_size,omitempty"`
-	MaxSize           int    `json:"max_size,omitempty" yaml:"max_size,omitempty"`
-	UpdateStrategy    string `json:"update_strategy,omitempty" yaml:"update_strategy,omitempty"`
-	Taints			  []Taint  `json:"taints,omitempty" yaml:"taints,omitempty"`
-	Labels			  map[string]string	`json:"labels,omitempty" yaml:"labels,omitempty"`
+	DesiredSize       int               `json:"desired_size,omitempty"       yaml:"desired_size,omitempty"`
+	EnableAutoScaling bool              `json:"enable_autoscaling,omitempty" yaml:"enable_autoscaling,omitempty"`
+	MinSize           int               `json:"min_size,omitempty"           yaml:"min_size,omitempty"`
+	MaxSize           int               `json:"max_size,omitempty"           yaml:"max_size,omitempty"`
+	UpdateStrategy    string            `json:"update_strategy,omitempty"    yaml:"update_strategy,omitempty"`
+	Taints            []Taint           `json:"taints,omitempty"             yaml:"taints,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"             yaml:"labels,omitempty"`
 }
 
 // AddWorkerPools represents the request body to add worker pools into cluster
-func (c *kubernetesEngineService) AddWorkerPools(ctx context.Context, id string, awp *AddWorkerPoolsRequest) ([]*ExtendedWorkerPool, error) {
+func (c *kubernetesEngineService) AddWorkerPools(
+	ctx context.Context,
+	id string,
+	awp *AddWorkerPoolsRequest,
+) ([]*ExtendedWorkerPool, error) {
 	req, err := c.client.NewRequest(ctx, http.MethodPost, kubernetesServiceName, c.itemPath(id), &awp)
 	if err != nil {
 		return nil, err
@@ -102,8 +106,19 @@ func (c *kubernetesEngineService) AddWorkerPools(ctx context.Context, id string,
 }
 
 // RecycleNode - Delete a node and replace by a new one with the same configuration
-func (c *kubernetesEngineService) RecycleNode(ctx context.Context, clusterUID string, poolID string, nodePhysicalID string) error {
-	req, err := c.client.NewRequest(ctx, http.MethodPut, kubernetesServiceName, strings.Join([]string{clusterPath, clusterUID, poolID, nodePhysicalID}, "/"), nil)
+func (c *kubernetesEngineService) RecycleNode(
+	ctx context.Context,
+	clusterUID string,
+	poolID string,
+	nodePhysicalID string,
+) error {
+	req, err := c.client.NewRequest(
+		ctx,
+		http.MethodPut,
+		kubernetesServiceName,
+		strings.Join([]string{clusterPath, clusterUID, poolID, nodePhysicalID}, "/"),
+		nil,
+	)
 	if err != nil {
 		return err
 	}
@@ -117,7 +132,13 @@ func (c *kubernetesEngineService) RecycleNode(ctx context.Context, clusterUID st
 
 // DeleteClusterWorkerPool - Delete a worker pool in the given cluster
 func (c *kubernetesEngineService) DeleteClusterWorkerPool(ctx context.Context, clusterUID string, PoolID string) error {
-	req, err := c.client.NewRequest(ctx, http.MethodDelete, kubernetesServiceName, strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"), nil)
+	req, err := c.client.NewRequest(
+		ctx,
+		http.MethodDelete,
+		kubernetesServiceName,
+		strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"),
+		nil,
+	)
 	if err != nil {
 		return err
 	}
@@ -130,9 +151,19 @@ func (c *kubernetesEngineService) DeleteClusterWorkerPool(ctx context.Context, c
 }
 
 // GetClusterWorkerPool - Get a cluster worker pool with additional node information
-func (c *kubernetesEngineService) GetClusterWorkerPool(ctx context.Context, clusterUID string, PoolID string) (*WorkerPoolWithNodes, error) {
+func (c *kubernetesEngineService) GetClusterWorkerPool(
+	ctx context.Context,
+	clusterUID string,
+	PoolID string,
+) (*WorkerPoolWithNodes, error) {
 	var pool *WorkerPoolWithNodes
-	req, err := c.client.NewRequest(ctx, http.MethodGet, kubernetesServiceName, strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"), nil)
+	req, err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		kubernetesServiceName,
+		strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"),
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +179,19 @@ func (c *kubernetesEngineService) GetClusterWorkerPool(ctx context.Context, clus
 }
 
 // UpdateClusterWorkerPool - Update a worker pool in the given cluster
-func (c *kubernetesEngineService) UpdateClusterWorkerPool(ctx context.Context, clusterUID string, PoolID string, uwp *UpdateWorkerPoolRequest) error {
-	req, err := c.client.NewRequest(ctx, http.MethodPatch, kubernetesServiceName, strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"), &uwp)
+func (c *kubernetesEngineService) UpdateClusterWorkerPool(
+	ctx context.Context,
+	clusterUID string,
+	PoolID string,
+	uwp *UpdateWorkerPoolRequest,
+) error {
+	req, err := c.client.NewRequest(
+		ctx,
+		http.MethodPatch,
+		kubernetesServiceName,
+		strings.Join([]string{clusterPath, clusterUID, PoolID}, "/"),
+		&uwp,
+	)
 	if err != nil {
 		return err
 	}
@@ -162,8 +204,19 @@ func (c *kubernetesEngineService) UpdateClusterWorkerPool(ctx context.Context, c
 }
 
 // DeleteClusterWorkerPoolNode - Delete a node in the given worker pool
-func (c *kubernetesEngineService) DeleteClusterWorkerPoolNode(ctx context.Context, clusterUID string, PoolID string, NodeID string) error {
-	req, err := c.client.NewRequest(ctx, http.MethodDelete, kubernetesServiceName, strings.Join([]string{clusterPath, clusterUID, PoolID, NodeID}, "/"), nil)
+func (c *kubernetesEngineService) DeleteClusterWorkerPoolNode(
+	ctx context.Context,
+	clusterUID string,
+	PoolID string,
+	NodeID string,
+) error {
+	req, err := c.client.NewRequest(
+		ctx,
+		http.MethodDelete,
+		kubernetesServiceName,
+		strings.Join([]string{clusterPath, clusterUID, PoolID, NodeID}, "/"),
+		nil,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Bizfly terraform client hiện đang không support trường _ProvisionType_ cho worker và cluster
- Trong body create cluster của gobizfly có trường này. Vấn đề ở đây là phía bke-api nếu không truyền trường này thì không sao. Nhưng có truyền mà sai value thì sẽ lỗi validate. Vậy nên chủ động set omit empty cho trường ProvisionType này để backward compatible với Bizfly terraform client