### PR TITLE
remove validate replicas when create MariaDB/ MySQL

### DIFF
--- a/cloud_database.go
+++ b/cloud_database.go
@@ -28,10 +28,6 @@ var (
 	ErrRequireFlavorName = errors.New("resize flavor require flavor_name")
 	// ErrRequireNewSize for resource resize volume
 	ErrRequireNewSize = errors.New("resize volume require new_size")
-	// ErrMongoDBReplicas for create resource datastore type mongodb
-	ErrMongoDBReplicas = errors.New("MongoDB can't have replica node")
-	// ErrMariaDBSecondariesQuantity for create resource datastore type mariadb
-	ErrMariaDBSecondariesQuantity = errors.New("MariaDB can't have more than one secondary node")
 	// ErrListOption for get resource with list option
 	ErrListOption = errors.New("can't determine resource list option")
 )

--- a/cloud_database_instances.go
+++ b/cloud_database_instances.go
@@ -233,14 +233,6 @@ func (ins *cloudDatabaseInstances) ListBackupSchedules(ctx context.Context, inst
 
 // Create a new instances
 func (ins *cloudDatabaseInstances) Create(ctx context.Context, icr *CloudDatabaseInstanceCreate) (*CloudDatabaseInstance, error) {
-	if icr.Datastore.Type == mongoDB && icr.Replicas != nil {
-		return nil, ErrMongoDBReplicas
-	}
-
-	if icr.Datastore.Type == mariaDB && icr.Secondaries != nil && icr.Secondaries.Quantity > 1 {
-		return nil, ErrMariaDBSecondariesQuantity
-	}
-
 	req, err := ins.client.NewRequest(ctx, http.MethodPost, databaseServiceName, cloudDatabaseInstancesResourcePath, &icr)
 	if err != nil {
 		return nil, err
@@ -261,14 +253,6 @@ func (ins *cloudDatabaseInstances) Create(ctx context.Context, icr *CloudDatabas
 
 // CreateSuggestion get suggestion when create a new instance
 func (ins *cloudDatabaseInstances) CreateSuggestion(ctx context.Context, icr *CloudDatabaseInstanceCreate) (*CloudDatabaseSuggestion, error) {
-	if icr.Datastore.Type == mongoDB && icr.Replicas != nil {
-		return nil, ErrMongoDBReplicas
-	}
-
-	if icr.Datastore.Type == mariaDB && icr.Secondaries != nil && icr.Secondaries.Quantity > 1 {
-		return nil, ErrMariaDBSecondariesQuantity
-	}
-
 	// set true for get suggestion
 	icr.Suggestion = true
 


### PR DESCRIPTION
Currently, MariaDB & MySQL being supported High Availability. So, we can remove replicas concept in this datastores